### PR TITLE
Allow to query if (the pattern/Automaton of) Generex is infinite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,5 +390,11 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<version>2.0.0.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/mifmif/common/regex/Generex.java
+++ b/src/main/java/com/mifmif/common/regex/Generex.java
@@ -123,6 +123,19 @@ public class Generex implements Iterable {
 	}
 
 	/**
+	 * Tells whether or not the given pattern (or {@code Automaton}) is infinite, that is, generates an infinite number of
+	 * strings.
+	 * <p>
+	 * For example, the pattern "a+" generates an infinite number of strings whether "a{5}" does not.
+	 *
+	 * @return {@code true} if the pattern (or {@code Automaton}) generates an infinite number of strings, {@code false}
+	 *         otherwise
+	 */
+	public boolean isInfinite() {
+		return !automaton.isFinite();
+	}
+
+	/**
 	 * @return first string in lexicographical order that is matched by the
 	 *         given pattern.
 	 */

--- a/src/test/java/com/mifmif/common/regex/GenerexUnitTest.java
+++ b/src/test/java/com/mifmif/common/regex/GenerexUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 y.mifrah
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mifmif.common.regex;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import dk.brics.automaton.Automaton;
+
+/**
+ * Unit test for {@code Generex}.
+ */
+public class GenerexUnitTest {
+
+	@Test
+	public void shouldReturnTrueWhenQueryingIfInfiniteWithInfinitePattern() {
+		// Given
+		String infinitePattern = "a+";
+		Generex generex = new Generex(infinitePattern);
+		// When
+		boolean infinite = generex.isInfinite();
+		// Then
+		assertThat(infinite, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldReturnFalseWhenQueryingIfInfiniteWithFinitePattern() {
+		// Given
+		String finitePattern = "a{5}";
+		Generex generex = new Generex(finitePattern);
+		// When
+		boolean infinite = generex.isInfinite();
+		// Then
+		assertThat(infinite, is(equalTo(false)));
+	}
+
+	@Test(expected = Exception.class)
+	public void shouldFailWhenQueryingIfInfiniteWithUndefinedAutomaton() {
+		// Given
+		Generex generex = new Generex((Automaton) null);
+		// When
+		generex.isInfinite();
+		// Then = Exception
+	}
+
+	@Test
+	public void shouldReturnTrueWhenQueryingIfInfiniteWithInfiniteAutomaton() {
+		// Given
+		Automaton infiniteAutomaton = Automaton.makeChar('a').repeat(1); // same as "a+"
+		Generex generex = new Generex(infiniteAutomaton);
+		// When
+		boolean infinite = generex.isInfinite();
+		// Then
+		assertThat(infinite, is(equalTo(true)));
+	}
+
+	@Test
+	public void shouldReturnFalseWhenQueryingIfInfiniteWithFiniteAutomaton() {
+		// Given
+		Automaton finiteAutomaton = Automaton.makeChar('a').repeat(5, 5); // same as "a{5}"
+		Generex generex = new Generex(finiteAutomaton);
+		// When
+		boolean infinite = generex.isInfinite();
+		// Then
+		assertThat(infinite, is(equalTo(false)));
+	}
+}


### PR DESCRIPTION
Add instance method "boolean Generex.isInfinite()" that allows to query
if the pattern/Automaton of Generex is (or not) infinite. The method
uses the state of Automaton to know if the pattern is infinite.
Add class GenerexUnitTest to test the behaviour of the new method.
Add test dependency org.hamcrest:hamcrest-junit:2.0.0.0 (used by the new
tests).
The change allows to check, at runtime, if a given pattern is infinite,
for example, to not attempt to get all generated Strings, or, disallow
the use of infinite patterns.