### PR TITLE
Correct iterator's strings shown in examples, README and Main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ Here is the sample Java code demonstrating library usage:
 		while (iterator.hasNext()) {
 			System.out.print(iterator.next() + " ");
 		}
-		// it print 0a 0b 0c 0e 0ee 0e 0e 0f 0fe 0f 0f 0g 0ge 0g 0g 1a 1b 1c 1e
-		// 1ee 1e 1e 1f 1fe 1f 1f 1g 1ge 1g 1g 2a 2b 2c 2e 2ee 2e 2e 2f 2fe 2f 2f 2g
-		// 2ge 2g 2g 3a 3b 3c 3e 3ee 3e 3e 3f 3fe 3f 3f 3g 3ge 3g 3g 1ee
+		// it prints:
+		// 0a 0b 0c 0e 0ee 0ef 0eg 0f 0fe 0ff 0fg 0g 0ge 0gf 0gg
+		// 1a 1b 1c 1e 1ee 1ef 1eg 1f 1fe 1ff 1fg 1g 1ge 1gf 1gg
+		// 2a 2b 2c 2e 2ee 2ef 2eg 2f 2fe 2ff 2fg 2g 2ge 2gf 2gg
+		// 3a 3b 3c 3e 3ee 3ef 3eg 3f 3fe 3ff 3fg 3g 3ge 3gf 3gg
 		
 ```
 

--- a/src/main/java/com/mifmif/common/regex/Main.java
+++ b/src/main/java/com/mifmif/common/regex/Main.java
@@ -42,10 +42,11 @@ public class Main {
 		while (iterator.hasNext()) {
 			System.out.print(iterator.next() + " ");
 		}
-		// it print 0a 0b 0c 0e 0ee 0e 0e 0f 0fe 0f 0f 0g 0ge 0g 0g 1a 1b 1c 1e
-		// 1ee
-		// 1e 1e 1f 1fe 1f 1f 1g 1ge 1g 1g 2a 2b 2c 2e 2ee 2e 2e 2f 2fe 2f 2f 2g
-		// 2ge 2g 2g 3a 3b 3c 3e 3ee 3e 3e 3f 3fe 3f 3f 3g 3ge 3g 3g 1ee
+		// it prints:
+		// 0a 0b 0c 0e 0ee 0ef 0eg 0f 0fe 0ff 0fg 0g 0ge 0gf 0gg
+		// 1a 1b 1c 1e 1ee 1ef 1eg 1f 1fe 1ff 1fg 1g 1ge 1gf 1gg
+		// 2a 2b 2c 2e 2ee 2ef 2eg 2f 2fe 2ff 2fg 2g 2ge 2gf 2gg
+		// 3a 3b 3c 3e 3ee 3ef 3eg 3f 3fe 3ff 3fg 3g 3ge 3gf 3gg
 
 		// Generate random String
 		String randomStr = generex.random();


### PR DESCRIPTION
Some of the strings are repeated, for example, it shows "0e" and "0e"
instead of "0ef" and "0eg", respectively.
Show each entry range in its own line as it's easier to read the strings
generated.