### PR TITLE
Change classes' license headers from JavaDoc comment to plain comment

### DIFF
--- a/src/main/java/com/mifmif/common/regex/Generex.java
+++ b/src/main/java/com/mifmif/common/regex/Generex.java
@@ -1,4 +1,4 @@
-/**
+/*
   * Copyright 2014 y.mifrah
  *
 

--- a/src/main/java/com/mifmif/common/regex/GenerexIterator.java
+++ b/src/main/java/com/mifmif/common/regex/GenerexIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 y.mifrah
  *
 

--- a/src/main/java/com/mifmif/common/regex/Main.java
+++ b/src/main/java/com/mifmif/common/regex/Main.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 y.mifrah
  *
 

--- a/src/main/java/com/mifmif/common/regex/Node.java
+++ b/src/main/java/com/mifmif/common/regex/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 y.mifrah
  *
 

--- a/src/main/java/com/mifmif/common/regex/util/Iterable.java
+++ b/src/main/java/com/mifmif/common/regex/util/Iterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 y.mifrah
  *
 

--- a/src/main/java/com/mifmif/common/regex/util/Iterator.java
+++ b/src/main/java/com/mifmif/common/regex/util/Iterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 y.mifrah
  *
 

--- a/src/test/java/com/mifmif/common/regex/GenerexRandomTest.java
+++ b/src/test/java/com/mifmif/common/regex/GenerexRandomTest.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.mifmif.common.regex;
 
 import java.util.Arrays;


### PR DESCRIPTION
Change all license headers form JavaDoc comment to plain Java comment.
Remove empty JavaDoc comment in GenerexRandomTest (where the license
header is usually placed).