### PR TITLE
Overload Generex ctor to accept Random

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
-				<version>2.3.1</version>
+				<version>2.5.2</version>
 				<configuration>
 					<file>target/${project.artifactId}-${project.version}.jar</file>
 					<groupId>${project.groupId}</groupId>
@@ -109,7 +109,7 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.5.1</version>
 				<configuration>
 					<source>1.5</source>
 					<target>1.5</target>
@@ -118,7 +118,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.0.2</version>
 				<configuration>
 					<excludes>
 						<exclude>*</exclude>
@@ -153,7 +153,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.6</version>
 				<configuration>
 					<descriptors>
 						<descriptor>./sources.xml</descriptor>
@@ -163,12 +163,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.10</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.10.3</version>
 				<configuration>
 					<show>private</show>
 					<nohelp>false</nohelp>
@@ -188,7 +188,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.8.2</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -198,7 +198,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -242,7 +242,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.2</version>
+				<version>1.6.3</version>
 				<executions>
 					<execution>
 						<id>default-deploy</id>
@@ -261,7 +261,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.6</version>
 				<configuration>
 					<failOnViolation>true</failOnViolation>
 					<excludeRoots>
@@ -336,7 +336,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>javancss-maven-plugin</artifactId>
-				<version>2.0-beta-2</version>
+				<version>2.0</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<ccnLimit>10</ccnLimit>
@@ -357,7 +357,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.2</version>
+				<version>3.0.3</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<failOnError>true</failOnError>
@@ -387,7 +387,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/mifmif/common/regex/Generex.java
+++ b/src/main/java/com/mifmif/common/regex/Generex.java
@@ -71,15 +71,23 @@ public class Generex implements Iterable {
 	}
 
 	public Generex(String regex) {
-		regex=requote(regex);
-		regExp = createRegExp(regex);
-		automaton = regExp.toAutomaton();
-		random = new Random();
+		this(regex, new Random());
 	}
 
 	public Generex(Automaton automaton) {
+		this(automaton, new Random());
+	}
+
+	public Generex(String regex, Random random) {
+		regex=requote(regex);
+		regExp = createRegExp(regex);
+		automaton = regExp.toAutomaton();
+		this.random = random;
+	}
+
+	public Generex(Automaton automaton, Random random) {
 		this.automaton = automaton;
-		random = new Random();
+		this.random = random;
 	}
 
 	/**

--- a/src/test/java/com/mifmif/common/regex/GenerexProvidedRandomTest.java
+++ b/src/test/java/com/mifmif/common/regex/GenerexProvidedRandomTest.java
@@ -1,0 +1,93 @@
+package com.mifmif.common.regex;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class GenerexProvidedRandomTest {
+    private final String pattern;
+    private final int minLength;
+    private final int maxLength;
+    private final Random random;
+    private final String expectedResult;
+
+    public GenerexProvidedRandomTest(
+        String description,
+        String patternValue,
+        int minLengthValue,
+        int maxLengthValue,
+        String expectedResult) {
+
+        this.pattern = patternValue;
+        this.minLength = minLengthValue;
+        this.maxLength = maxLengthValue;
+        this.random = new Random(- 1L);
+        this.expectedResult = expectedResult;
+    }
+
+    @Parameters(name = "Test random: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "Sample multicharacter expression", "[A-Z]{5,9}", 4, 8, "VFWMLRSM" },
+            { "Sample expression", "[0-3]([a-c]|[e-g]{1,2})", 1, 3, "1c" },
+            { "E-mail format", "([a-z0-9]+)[@]([a-z0-9]+)[.]([a-z0-9]+)", 8, 24, "59w8@i.0mz0" },
+            { "Any number", "(\\d+)", 4, 8, "5488" },
+            { "Any non-number", "(\\D+)", 4, 8, "\u0011朂\u0006\u0000" },
+            { "Any word", "(\\w+)", 4, 8, "V_M8" },
+            { "Any non-word", "(\\W+)", 4, 8, "`窱\\?" },
+            { "Any text", "(.*)", 4, 8, "̤駍" }
+        });
+    }
+
+    @Test
+    public void testSimpleRandom() {
+        Generex generex = new Generex(pattern, random);
+
+        String result = generex.random();
+
+        Assert.assertTrue(result.startsWith(expectedResult));
+        Assert.assertTrue(
+            String.format("The string '%s' doesn't match the '%s' pattern", result, pattern),
+            result.matches(pattern));
+    }
+
+    @Test
+    public void testRandomWithMinLength() {
+        Generex generex = new Generex(pattern, random);
+
+        String result = generex.random(minLength);
+
+        Assert.assertTrue(result.startsWith(expectedResult));
+        Assert.assertTrue(
+            String.format("The string '%s' doesn't match the '%s' pattern", result, pattern),
+            result.matches(pattern));
+        Assert.assertTrue(
+            String.format("The string '%s' size doesn't fit the minimal size of %d", result, minLength),
+            result.length() >= minLength);
+    }
+
+    @Test
+    public void testRandomWithMaxLength() {
+        Generex generex = new Generex(pattern, random);
+
+        String result = generex.random(minLength, maxLength);
+
+        Assert.assertTrue(result.startsWith(expectedResult));
+        Assert.assertTrue(
+            String.format("The string '%s' doesn't match the '%s' pattern", result, pattern),
+            result.matches(pattern));
+        Assert.assertTrue(
+            String.format("The string '%s' size doesn't fit the minimal size of %d", result, minLength),
+            result.length() >= minLength);
+        Assert.assertTrue(
+            String.format("The string '%s' size doesn't fit the maximal size of %d", result, maxLength),
+            result.length() <= maxLength);
+    }
+}


### PR DESCRIPTION
This is useful for applications that want to use Generex but control the
source of randomness. junit-quickcheck, in particular, could use this
so that a generator of strings that match a particular pattern can be made,
using the source of randomness that junit-quickcheck passes to its generators,
rather than having a separate source of randomness for Generex, which would
hinder repeatability of tests.