### PR TITLE
Added Iterator compatibility with Java built-ins

### DIFF
--- a/findBugsExclude.xml
+++ b/findBugsExclude.xml
@@ -5,4 +5,12 @@
        <Method name="build" />
        <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
      </Match>
+    <Match>
+        <Class name="com.mifmif.common.regex.util.Iterable"/>
+        <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
+    </Match>
+    <Match>
+        <Class name="com.mifmif.common.regex.util.Iterator"/>
+        <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
+    </Match>
 </FindBugsFilter>

--- a/src/main/java/com/mifmif/common/regex/GenerexIterator.java
+++ b/src/main/java/com/mifmif/common/regex/GenerexIterator.java
@@ -82,6 +82,13 @@ public class GenerexIterator implements Iterator {
 	}
 
 	/**
+	 * Always throws an {@link UnsupportedOperationException} (default behavior for Java 8).
+	 */
+	public void remove() {
+		throw new UnsupportedOperationException("remove");
+	}
+
+	/**
 	 * A step, in the iteration process, to build a string using {@code State}s.
 	 * <p>
 	 * It's responsible to keep the information of a {@code State}, like current char and transitions that need to be followed.

--- a/src/main/java/com/mifmif/common/regex/GenerexIterator.java
+++ b/src/main/java/com/mifmif/common/regex/GenerexIterator.java
@@ -84,6 +84,7 @@ public class GenerexIterator implements Iterator {
 	/**
 	 * Always throws an {@link UnsupportedOperationException} (default behavior for Java 8).
 	 */
+	@Override
 	public void remove() {
 		throw new UnsupportedOperationException("remove");
 	}

--- a/src/main/java/com/mifmif/common/regex/util/Iterable.java
+++ b/src/main/java/com/mifmif/common/regex/util/Iterable.java
@@ -21,6 +21,6 @@ package com.mifmif.common.regex.util;
  * @author y.mifrah
  *
  */
-public interface Iterable {
+public interface Iterable extends java.lang.Iterable<String>{
 	Iterator iterator();
 }

--- a/src/main/java/com/mifmif/common/regex/util/Iterator.java
+++ b/src/main/java/com/mifmif/common/regex/util/Iterator.java
@@ -21,7 +21,7 @@ package com.mifmif.common.regex.util;
  * @author y.mifrah
  *
  */
-public interface Iterator {
+public interface Iterator extends java.util.Iterator<String>{
 	boolean hasNext();
 	String next();
 }

--- a/src/test/java/com/mifmif/common/regex/GenerexIteratorTest.java
+++ b/src/test/java/com/mifmif/common/regex/GenerexIteratorTest.java
@@ -70,4 +70,20 @@ public class GenerexIteratorTest {
 		}
 		Assert.assertEquals("Incorrect number of iterated strings,", generex.matchedStringsSize(), count - 1);
 	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testIterateRemoveFirstShouldAlwaysThrowException() {
+		Iterator iterator = generex.iterator();
+		iterator.remove();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testIterateRemoveLastShouldAlwaysThrowException() {
+		Iterator iterator = generex.iterator();
+		while (iterator.hasNext()) {
+			// Iterate through all entries until last one
+			iterator.next();
+		}
+		iterator.remove();
+	}
 }


### PR DESCRIPTION
Minimum language level - 1.6
Shouldn't have any backwards compatibility issues because the existing classes extend the Java source classes.  `com.mifmif.common.regex.util.Iterator` now extends `java.util.Iterator` and `com.mifmif.common.regex.util.Iterable` now extends `java.lang.Iterable`.  The change means that Java 8 can take advantage of Streams and `Iterator#forEach` support without requiring a compatibility wrapper.