### PR TITLE
Modernize build a bit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,9 +355,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.3</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>3.1.10</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<failOnError>true</failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -380,9 +380,9 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>dk.brics.automaton</groupId>
+			<groupId>dk.brics</groupId>
 			<artifactId>automaton</artifactId>
-			<version>1.11-8</version>
+			<version>1.12-1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/mifmif/common/regex/Generex.java
+++ b/src/main/java/com/mifmif/common/regex/Generex.java
@@ -125,11 +125,11 @@ public class Generex implements Iterable {
     }
 
     /**
-     * @param indexOrder ( 1<= indexOrder <=n)
+     * @param indexOrder ( 1&lt;= indexOrder &lt;=n)
      * @return The matched string by the given pattern in the given it's order in the sorted list of matched String.<br>
      * <code>indexOrder</code> between 1 and <code>n</code> where <code>n</code> is the number of matched String.<br> If
-     * indexOrder >= n , return an empty string. if there is an infinite number of String that matches the given Regex,
-     * the method throws {@code StackOverflowError}
+     * indexOrder &gt;= n , return an empty string. if there is an infinite number of String that matches the given
+     * Regex, the method throws {@code StackOverflowError}
      */
     public String getMatchedString(int indexOrder) {
         buildRootNode();
@@ -311,8 +311,8 @@ public class Generex implements Iterable {
     }
 
     /**
-     * Generate and return a random String that match the pattern used in this Generex, and the string has a length >=
-     * <code>minLength</code>
+     * Generate and return a random String that match the pattern used in this Generex, and the string has a length
+     * &gt;= <code>minLength</code>
      *
      * @param minLength
      * @return
@@ -322,8 +322,8 @@ public class Generex implements Iterable {
     }
 
     /**
-     * Generate and return a random String that match the pattern used in this Generex, and the string has a length >=
-     * <code>minLength</code> and <= <code>maxLength</code>
+     * Generate and return a random String that match the pattern used in this Generex, and the string has a length
+     * &gt;= <code>minLength</code> and &lt;= <code>maxLength</code>
      *
      * @param minLength
      * @param maxLength


### PR DESCRIPTION
This fixes:
- compilation with recent maven versions, which fail to run findbugs-maven-plugin
- javadoc generation with recent JDK, which complains about use of '<' and '>' in javadocs

Finally it updates automaton version and reference, as it has moved to a different groupId.