### PR TITLE
Ability to change syntax flags & Generex extensibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.mifmif</groupId>
 	<artifactId>generex</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.4</version>
 	<name>Generex</name>
 	<url>https://github.com/mifmif/Generex/tree/master</url>
 	<description>Generex A Java Library for regex to Strings generation</description>


### PR DESCRIPTION
### Motivation
Have you ever wondered why the characters `@&<#~` behave very weirdly in generex? Yes, Generex does use [this regex grammar](https://www.brics.dk/automaton/doc/index.html?dk/brics/automaton/RegExp.html) and not the Java one we all are used to, so these are special characters. Fear no more: we can actually turn off the syntax flags on the RegExp!

### Features
- adds the possibility to define different syntax flags for the input regex by overloading the constructor & createRegExp()
- changes static methods (`createRegExp`, `requote`) to protected, so they can be reused in subclasses (typically in the constructor)
- change `regExp`, `automaton` fields to protected, subclasses will surely appreciate it

All of these changes are backwards-compatible, because only new overloaded methods are added and the default behaviour is preserved. Also changing stuff from `private` to `protected` is OK because it is less restrictive now.

---
**Disclaimer:** This branch is not compilable right now because of maven error
> Source option 5 is no longer supported. Use 6 or later.

PR #48 does a good job of updating the project and my  original feature branch https://github.com/HawkSK/Generex/tree/change_syntax_flags was built upon #48, so pull that branch if you want to try this feature. This PR is only the separate independent feature in Generex class.
_Note:_ I used new version `1.0.4` because `1.0.3` is used in #48.